### PR TITLE
fix sorting to work on browsers other than Firefox

### DIFF
--- a/client/src/components/Setlists/Setlists.js
+++ b/client/src/components/Setlists/Setlists.js
@@ -34,11 +34,11 @@ const Setlists = () => {
         const B = b.date;
 
         if (A.year !== B.year) {
-          return A.year + B.year;
+          return B.year - A.year;
         } else if (A.month !== B.month) {
-          return A.month + B.month;
+          return B.month - A.month;
         } else {
-          return A.day + B.day;
+          return B.day - A.day;
         }
       });
 


### PR DESCRIPTION
Firefox interprets Array.prototype.sort() differently than other browsers, and as such, the results seem to not sort correctly on Chrome, et al.

This should work... I think?